### PR TITLE
return error when acl is not found to avoid duplicates

### DIFF
--- a/ciscoasa/resource_ciscoasa_access_in_rules.go
+++ b/ciscoasa/resource_ciscoasa_access_in_rules.go
@@ -134,7 +134,7 @@ func resourceCiscoASAAccessInRulesRead(d *schema.ResourceData, meta interface{})
 		if strings.Contains(err.Error(), "RESOURCE-NOT-FOUND") {
 			log.Printf("[DEBUG] Rule %s no longer exists", d.Id())
 			d.SetId("")
-			return nil
+			return err
 		}
 
 		return fmt.Errorf("Error reading interface %s rules: %v", d.Id(), err)

--- a/ciscoasa/resource_ciscoasa_access_out_rules.go
+++ b/ciscoasa/resource_ciscoasa_access_out_rules.go
@@ -134,7 +134,7 @@ func resourceCiscoASAAccessOutRulesRead(d *schema.ResourceData, meta interface{}
 		if strings.Contains(err.Error(), "RESOURCE-NOT-FOUND") {
 			log.Printf("[DEBUG] Rule %s no longer exists", d.Id())
 			d.SetId("")
-			return nil
+			return err
 		}
 
 		return fmt.Errorf("Error reading interface %s rules: %v", d.Id(), err)

--- a/ciscoasa/resource_ciscoasa_acl.go
+++ b/ciscoasa/resource_ciscoasa_acl.go
@@ -134,7 +134,7 @@ func resourceCiscoASAACLRead(d *schema.ResourceData, meta interface{}) error {
 		if strings.Contains(err.Error(), "RESOURCE-NOT-FOUND") {
 			log.Printf("[DEBUG] ACL %s no longer exists", d.Id())
 			d.SetId("")
-			return nil
+			return err
 		}
 
 		return fmt.Errorf("Error reading ACL %s rules: %v", d.Id(), err)


### PR DESCRIPTION
Masking the error for terraform had the undesired effect of access-lists being recreated while they already exists. Although the actual cause is an empty result for a listing of an existing access-list probably due to a bug in the Cisco api, this is a cleaner way to handle this situation. 